### PR TITLE
Add auto-connect functionality for previously paired devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Una vez instalado globalmente, puedes ejecutar la herramienta desde la línea de
 
 -  `--qr` o `-q`: Muestra un código QR para el emparejamiento.
 
+-  `--qr_connect` o `-qc`: Muestra un código QR para el emparejamiento y se conecta automáticamente al dispositivo sin necesidad de usar posteriormente --connect.
+
 -  `--pair` o `-p`: Empareja un dispositivo utilizando un código de emparejamiento.
+
+-  `--pair_connect` o `-pc`: Empareja un dispositivo utilizando un código de emparejamiento y se conecta automáticamente al dispositivo sin necesidad de usar posteriormente --connect.
 
 -  `--connect` o `-c`: Conecta a un dispositivo disponible en la red.
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 const { Select } = require('enquirer');
 const { nanoid } = require('nanoid');
 const { pairDevice, connectToDevice } = require('./utils/adbUtils');
-const { discoverDevices, startDiscoverQr } = require('./discovery/deviceDiscovery');
+const { discoverDevices, startDiscoverQr, startPairAndConnect } = require('./discovery/deviceDiscovery');
 const { showQR } = require('./utils/qrUtils');
 
 const nameId = nanoid();
@@ -19,7 +19,9 @@ async function promptForAction() {
     message: '🚀 Please select an action to proceed:',
     choices: [
       { value: 'qr', name: '📱 Pair device with QR code' },
+      { value: 'qr_connect', name: '📱 Pair and connect device with QR code' },
       { value: 'pair', name: '🔑 Pair device with pairing code' },
+      { value: 'pair_connect', name: '🔑 Pair and connect device with pairing code' },
       { value: 'connect', name: '🔌 Connect to a device' },
     ],
     result(value) {
@@ -43,9 +45,9 @@ async function handleAction(action) {
       await startDiscoverQr(name, password);
       break;
     case 'pair':
-      const deviceToPair = await discoverDevices(true);
-      if (deviceToPair) {
-        await pairDevice(deviceToPair, password);
+      const device = await discoverDevices(true);
+      if (device) {
+        await pairDevice(device);
       }
       break;
     case 'connect':
@@ -53,6 +55,13 @@ async function handleAction(action) {
       if (deviceToConnect) {
         await connectToDevice(deviceToConnect);
       }
+      break;
+    case 'qr_connect':
+      showQR(name, password);
+      await startDiscoverQr(name, password, { autoConnect: true });
+      break;
+    case 'pair_connect':
+      await startPairAndConnect();
       break;
     default:
       console.error('⚠️ Unknown action:', action);
@@ -69,8 +78,12 @@ async function main() {
 
     if (args.includes('--qr') || args.includes('-q')) {
       action = 'qr';
+    } else if (args.includes('--qr_connect') || args.includes('-qc')) {
+      action = 'qr_connect';
     } else if (args.includes('--pair') || args.includes('-p')) {
       action = 'pair';
+    } else if (args.includes('--pair_connect') || args.includes('-pc')) {
+      action = 'pair_connect';
     } else if (args.includes('--connect') || args.includes('-c')) {
       action = 'connect';
     } else {

--- a/src/utils/adbUtils.js
+++ b/src/utils/adbUtils.js
@@ -66,10 +66,9 @@ async function promptUser(question) {
 /**
  * Initiates pairing with a device using adb pair command.
  * @param {Object} device - The device to pair with.
- * @param {string} password - The pairing password.
  * @returns {Promise<void>} A promise that resolves when pairing is complete.
  */
-async function pairDevice(device, password) {
+async function pairDevice(device) {
   handleProcessInterruption();
 
   return new Promise(function resolveRetry(resolve, reject) {


### PR DESCRIPTION
#1 feature added.
Hi there,

Thanks for your feedback! I’m pleased to let you know that the functionality you’re looking for is already available in the latest version. You can now use the --qr_connect (or -qc) option with adb-qc to pair and connect in one step by scanning a QR code. This should streamline the process and eliminate the extra step you mentioned.

Feel free to try it out and let me know if you have any other suggestions or questions!

Best regards,